### PR TITLE
Bug corrigé : langages fonctionnels

### DIFF
--- a/P2FixAnAppDotNetCode.Tests/ProductServiceTests.cs
+++ b/P2FixAnAppDotNetCode.Tests/ProductServiceTests.cs
@@ -23,7 +23,7 @@ namespace P2FixAnAppDotNetCode.Tests
             var products = productService.GetAllProducts();
 
             //Assert.IsType<List<Product>>(products);
-            Assert.IsType<Product[]>(products);
+            Assert.IsType<List<Product>>(products);
 
         }
 

--- a/P2FixAnAppDotNetCode/Controllers/ProductController.cs
+++ b/P2FixAnAppDotNetCode/Controllers/ProductController.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using P2FixAnAppDotNetCode.Models;
 using P2FixAnAppDotNetCode.Models.Services;
+using System.Collections.Generic;
 
 namespace P2FixAnAppDotNetCode.Controllers
 {
@@ -17,7 +18,7 @@ namespace P2FixAnAppDotNetCode.Controllers
 
         public IActionResult Index()
         {
-            Product[] products = _productService.GetAllProducts();
+            List<Product> products = _productService.GetAllProducts();
             return View(products);
         }
     }

--- a/P2FixAnAppDotNetCode/Models/Cart.cs
+++ b/P2FixAnAppDotNetCode/Models/Cart.cs
@@ -14,12 +14,17 @@ namespace P2FixAnAppDotNetCode.Models
         public IEnumerable<CartLine> Lines => GetCartLineList();
 
         /// <summary>
-        /// Return the actual cartline list
+        /// Add an internal list that stores all cart lines
         /// </summary>
-        /// <returns></returns>
+        private List<CartLine> _cartLines = new List<CartLine>();
+
+        /// <summary>
+        /// Return the current list of cart lines
+        /// </summary>
+        /// <returns>The list of cart lines.</returns>
         private List<CartLine> GetCartLineList()
         {
-            return new List<CartLine>();
+            return _cartLines;
         }
 
         /// <summary>
@@ -27,7 +32,21 @@ namespace P2FixAnAppDotNetCode.Models
         /// </summary>//
         public void AddItem(Product product, int quantity)
         {
-            // TODO implement the method
+            //TODO implement the method
+            var cartLines = GetCartLineList();
+            var existingLine = cartLines.FirstOrDefault(l => l.Product.Id == product.Id);
+            if (existingLine != null)
+            {
+                existingLine.Quantity += quantity;
+            }
+            else
+            {
+                cartLines.Add(new CartLine
+                {
+                    Product = product,
+                    Quantity = quantity
+                });
+            }
         }
 
         /// <summary>
@@ -42,7 +61,8 @@ namespace P2FixAnAppDotNetCode.Models
         public double GetTotalValue()
         {
             // TODO implement the method
-            return 0.0;
+            var cartLines = GetCartLineList();
+            return cartLines.Sum(l => l.Product.Price * l.Quantity);
         }
 
         /// <summary>
@@ -51,7 +71,17 @@ namespace P2FixAnAppDotNetCode.Models
         public double GetAverageValue()
         {
             // TODO implement the method
-            return 0.0;
+            var cartLines = GetCartLineList();
+           double totalQuantity = cartLines.Sum(l => l.Quantity);
+            if (totalQuantity > 0)
+            {
+                return GetTotalValue() / totalQuantity;
+            }
+            // If there are no lines, return 0
+            else
+            {
+                return 0.0;
+            }
         }
 
         /// <summary>
@@ -60,6 +90,13 @@ namespace P2FixAnAppDotNetCode.Models
         public Product FindProductInCartLines(int productId)
         {
             // TODO implement the method
+            var cartLines = GetCartLineList();
+            var foundLine = cartLines.FirstOrDefault(l => l.Product.Id == productId);
+            if (foundLine != null)
+            {
+                return foundLine.Product;
+            }
+            // If not found, return null
             return null;
         }
 

--- a/P2FixAnAppDotNetCode/Models/Order.cs
+++ b/P2FixAnAppDotNetCode/Models/Order.cs
@@ -12,18 +12,19 @@ namespace P2FixAnAppDotNetCode.Models
         [BindNever]
         public ICollection<CartLine> Lines { get; set; }
 
-        [Required(ErrorMessage = "ErrorMissingName")]
+        [Required(ErrorMessageResourceName = "ErrorMissingName", ErrorMessageResourceType = typeof(P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order))]
         public string Name { get; set; }
 
-        [Required(ErrorMessage = "ErrorMissingAddress")]
+        [Required(ErrorMessageResourceName = "ErrorMissingAddress", ErrorMessageResourceType = typeof(P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order))]
         public string Address { get; set; }
 
-        [Required(ErrorMessage = "ErrorMissingCity")]
+        [Required(ErrorMessageResourceName = "ErrorMissingCity", ErrorMessageResourceType = typeof(P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order))]
         public string City { get; set; }
 
+        [Required(ErrorMessageResourceName = "ErrorMissingZip", ErrorMessageResourceType = typeof(P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order))]
         public string Zip { get; set; }
 
-        [Required(ErrorMessage = "ErrorMissingCountry")]
+        [Required(ErrorMessageResourceName = "ErrorMissingCountry", ErrorMessageResourceType = typeof(P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order))]
         public string Country { get; set; }
 
         [BindNever]

--- a/P2FixAnAppDotNetCode/Models/Repositories/IProductRepository.cs
+++ b/P2FixAnAppDotNetCode/Models/Repositories/IProductRepository.cs
@@ -1,8 +1,12 @@
-﻿namespace P2FixAnAppDotNetCode.Models.Repositories
+﻿using System.Collections.Generic;
+
+namespace P2FixAnAppDotNetCode.Models.Repositories
 {
     public interface IProductRepository
     {
-        Product[] GetAllProducts();
+        List<Product> GetAllProducts();
+
+        Product GetProductById(int id);
 
         void UpdateProductStocks(int productId, int quantityToRemove);
     }

--- a/P2FixAnAppDotNetCode/Models/Repositories/ProductRepository.cs
+++ b/P2FixAnAppDotNetCode/Models/Repositories/ProductRepository.cs
@@ -12,6 +12,9 @@ namespace P2FixAnAppDotNetCode.Models.Repositories
 
         public ProductRepository()
         {
+            // Initialize the product list if it is null
+            if (_products != null)
+                return;
             _products = new List<Product>();
             GenerateProductData();
         }
@@ -32,10 +35,10 @@ namespace P2FixAnAppDotNetCode.Models.Repositories
         /// <summary>
         /// Get all products from the inventory
         /// </summary>
-        public Product[] GetAllProducts()
+        public List<Product> GetAllProducts()
         {
             List<Product> list = _products.Where(p => p.Stock > 0).OrderBy(p => p.Name).ToList();
-            return list.ToArray();
+            return list;
         }
 
         /// <summary>
@@ -48,6 +51,14 @@ namespace P2FixAnAppDotNetCode.Models.Repositories
 
             if (product.Stock == 0)
                 _products.Remove(product);
+        }
+
+        /// <summary>
+        /// Retrieve a product from the inventory by its id
+        /// </summary>
+        public Product GetProductById(int id)
+        {
+            return _products.FirstOrDefault(p => p.Id == id);
         }
     }
 }

--- a/P2FixAnAppDotNetCode/Models/Services/IProductService.cs
+++ b/P2FixAnAppDotNetCode/Models/Services/IProductService.cs
@@ -1,8 +1,10 @@
-﻿namespace P2FixAnAppDotNetCode.Models.Services
+﻿using System.Collections.Generic;
+
+namespace P2FixAnAppDotNetCode.Models.Services
 {
     public interface IProductService
     {
-        Product[] GetAllProducts();
+        List<Product> GetAllProducts();
         Product GetProductById(int id);
         void UpdateProductQuantities(Cart cart);
     }

--- a/P2FixAnAppDotNetCode/Models/Services/LanguageService.cs
+++ b/P2FixAnAppDotNetCode/Models/Services/LanguageService.cs
@@ -22,10 +22,24 @@ namespace P2FixAnAppDotNetCode.Models.Services
         /// </summary>
         public string SetCulture(string language)
         {
-            string culture = "";
             // TODO complete the code 
             // Default language is "en", french is "fr" and spanish is "es".
-            
+
+            string culture = "";
+
+            switch (language)
+            {
+                case "French":
+                    culture = "fr";
+                    break;
+                case "Spanish":
+                    culture = "es";
+                    break;
+                default:
+                    culture = "en";
+                    break;
+            }
+
             return culture;
         }
 

--- a/P2FixAnAppDotNetCode/Models/Services/ProductService.cs
+++ b/P2FixAnAppDotNetCode/Models/Services/ProductService.cs
@@ -1,4 +1,6 @@
 ﻿using P2FixAnAppDotNetCode.Models.Repositories;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
 
 namespace P2FixAnAppDotNetCode.Models.Services
 {
@@ -19,7 +21,7 @@ namespace P2FixAnAppDotNetCode.Models.Services
         /// <summary>
         /// Get all product from the inventory
         /// </summary>
-        public Product[] GetAllProducts()
+        public List<Product> GetAllProducts()
         {
             // TODO change the return type from array to List<T> and propagate the change
             // throughout the application
@@ -32,7 +34,8 @@ namespace P2FixAnAppDotNetCode.Models.Services
         public Product GetProductById(int id)
         {
             // TODO implement the method
-            return null;
+            return _productRepository.GetProductById(id);
+
         }
 
         /// <summary>
@@ -42,6 +45,10 @@ namespace P2FixAnAppDotNetCode.Models.Services
         {
             // TODO implement the method
             // update product inventory by using _productRepository.UpdateProductStocks() method.
+            foreach (var line in cart.Lines)
+            {
+                _productRepository.UpdateProductStocks(line.Product.Id, line.Quantity);
+            }
         }
     }
 }

--- a/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.en.resx
+++ b/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.en.resx
@@ -129,4 +129,7 @@
   <data name="ErrorMissingName" xml:space="preserve">
     <value>Please enter a name</value>
   </data>
+  <data name="ErrorMissingZip" xml:space="preserve">
+    <value>Please enter a postal code</value>
+  </data>
 </root>

--- a/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.es.resx
+++ b/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.es.resx
@@ -129,4 +129,7 @@
   <data name="ErrorMissingName" xml:space="preserve">
     <value>Introduzca un nombre</value>
   </data>
+  <data name="ErrorMissingZip" xml:space="preserve">
+    <value>Introduzca un código postal</value>
+  </data>
 </root>

--- a/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.fr.resx
+++ b/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Order.fr.resx
@@ -129,4 +129,7 @@
   <data name="ErrorMissingName" xml:space="preserve">
     <value>Veuillez renseigner un nom</value>
   </data>
+  <data name="ErrorMissingZip" xml:space="preserve">
+    <value>Veuillez renseigner un code postal</value>
+  </data>
 </root>

--- a/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Resources.cs
+++ b/P2FixAnAppDotNetCode/Resources/Models/ViewModels/Resources.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace P2FixAnAppDotNetCode.Resources.Models.ViewModels
 {
-    public static class Order
+    public class Order
     {
         private static ResourceManager resourceManager = new ResourceManager("P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order", Assembly.GetExecutingAssembly());
         private static CultureInfo resourceCulture;
@@ -36,6 +36,13 @@ namespace P2FixAnAppDotNetCode.Resources.Models.ViewModels
             get
             {
                 return resourceManager.GetString("ErrorMissingCountry", resourceCulture);
+            }
+        }
+        public static string ErrorMissingZip
+        {
+            get
+            {
+                return resourceManager.GetString("ErrorMissingZip", resourceCulture);
             }
         }
     }

--- a/P2FixAnAppDotNetCode/Startup.cs
+++ b/P2FixAnAppDotNetCode/Startup.cs
@@ -49,6 +49,8 @@ namespace P2FixAnAppDotNetCode
                     new CultureInfo("en"),
                     new CultureInfo("fr-FR"),
                     new CultureInfo("fr"),
+                    new CultureInfo("es-ES"),
+                    new CultureInfo("es"),
                 };
 
                 opts.DefaultRequestCulture = new RequestCulture("en");

--- a/P2FixAnAppDotNetCode/Views/Order/Index.cshtml
+++ b/P2FixAnAppDotNetCode/Views/Order/Index.cshtml
@@ -1,29 +1,49 @@
 ﻿@model P2FixAnAppDotNetCode.Models.Order
 
+@inject Microsoft.Extensions.Localization.IStringLocalizer<P2FixAnAppDotNetCode.Resources.Models.ViewModels.Order> Localizer
+@inject IViewLocalizer Localizer
+
 <h2>@Localizer["OrderTitle"]</h2>
 
 <div asp-validation-summary="All" class="text-danger"></div>
+
 <form asp-action="Index" method="post">
+
     <h3>@Localizer["ShipTo"]</h3>
     <div class="form-group">
         <label>@Localizer["Name"]*:</label><input asp-for="Name" class="form-control" />
+        <span asp-validation-for="Name" class="text-danger"></span>
     </div>
+
     <h3>@Localizer["Adress"]</h3>
     <div class="form-group">
         <label>@Localizer["Location"]*:</label><input asp-for="Address" class="form-control" />
+        <span asp-validation-for="Address" class="text-danger"></span>
     </div>
+
     <div class="row">
         <div class="form-group col-4">
             <label>@Localizer["City"]*:</label><input asp-for="City" class="form-control" />
+            <span asp-validation-for="City" class="text-danger"></span>
         </div>
+
         <div class="form-group col-4">
             <label>@Localizer["Zip"]:</label><input asp-for="Zip" class="form-control" />
+            <span asp-validation-for="Zip" class="text-danger"></span>
         </div>
+
         <div class="form-group col-4">
             <label>@Localizer["Country"]*:</label><input asp-for="Country" class="form-control" />
+            <span asp-validation-for="Country" class="text-danger"></span>
         </div>
     </div>
+
     <div class="text-center">
         <input class="btn btn-primary" type="submit" value="@Localizer["CompleteOrder"]" />
     </div>
+
 </form>
+
+@section Scripts {
+    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # DotNetprojet2
+## Présentation
+Ce projet est la version corrigée de l'application Lambazon, dans le cadre du Projet 2 de la formation C# .NET OpenClassrooms.
+
+## Lancer l'application en local
+### Si vous travaillez sur Visual Studio
+Vous pouvez désormais cloner le dépôt de la manière suivante : "fichier" ➡️ "cloner le dépôt" ➡️ https://github.com/damienlallemand54/DotNetprojet2.git  
+
+Vous pouvez ensuite vous placer sur la branche "dev", sur laquelle ont eu lieu les corrections, en saisissant la commande "git checkout dev"  
+
+### Si vous ne travaillez pas sur Visual Studio
+Vous pouvez lancer l'application de la manière suivante :  
+Le projet étant en .NET 9.0, vous avez besoin d'installer le .NET SDK 9.0.  
+Pour cloner le dépôt : git clone https://github.com/damienlallemand54/DotNetprojet2.git  
+Pour vous placer dans le dossier du projet : cd DotNetProjet2  
+Pour passer sur la branche dev : git checkout dev  
+
+### Dans les deux cas :
+Définissez bien P2FixAnAppDotNetCode comme projet de démarrage, et pas P2FixAnAppDotNetCode.Tests.
+
+## Corrections apportées 
+Ajout au panier  
+Confirmation de commande  
+Méthode SetCulture()  
+Implémentation des TODO  


### PR DESCRIPTION
Modification du LanguageService.cs dans Models/Services.
Ajout  du TODO dans “SetCulture”. 
Problème avec la consigne, impossible d'écrire "en" "es" et "fr", il faut écrire "French" "Spanish" et "English", à cause du fichier Default.cshtml dans Views/Shared/Components/LanguageSelector qui indique en option value “English” “French” et “Spanish”. 
Est-ce la norme ? 